### PR TITLE
Apply KMS policy to AP Kinesis Lambda role

### DIFF
--- a/templates/aspect-wfm-ap.template.yaml
+++ b/templates/aspect-wfm-ap.template.yaml
@@ -386,6 +386,23 @@ Resources:
           - firehose:PutRecord
           Resource:
           - Fn::Sub: arn:${AWS::Partition}:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/${OutputKinesisFirehose}
+  KinesisLambdaDecryptKinesisPolicy:
+    Condition: HasKinesisKmsKey
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: KinesisLambda_DecryptKinesisPolicy
+      Roles:
+      - !Ref KinesisLambdaRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action:
+          - kms:Decrypt
+          - kms:DescribeKey
+          - kms:GenerateDataKey
+          Resource:
+          - !Ref AgentEventStreamKmsArn
   KinesisLambdaFunction:
     Type: AWS::Lambda::Function
     DependsOn:


### PR DESCRIPTION
If you supply an agent event kinesis stream KMS ARN, attach a policy that allows the AP Kinesis Lambda to decrypt values using that KMS key